### PR TITLE
Add HTTP layer and in‑memory tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix"
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "vitest"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/src/infra/app.module.ts
+++ b/src/infra/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from './database/database.module';
+import { HttpModule } from './http/http.module';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, HttpModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/infra/http/controllers/client.controller.ts
+++ b/src/infra/http/controllers/client.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Patch, Param } from '@nestjs/common';
+import { TouchClientAnonymousUseCase } from '@/app/use-cases/client/touch-client-anonymous.use-case';
+import { ClientAnonymousPresenter } from '../presenters/client.presenter';
+
+@Controller('clients/anonymous')
+export class ClientController {
+  constructor(private readonly touchClient: TouchClientAnonymousUseCase) {}
+
+  @Patch(':id/touch')
+  async touch(@Param('id') id: string) {
+    const result = await this.touchClient.execute(id);
+    if (result.right()) {
+      return ClientAnonymousPresenter.toHTTP(result.value.client);
+    }
+    return null;
+  }
+}

--- a/src/infra/http/controllers/list.controller.ts
+++ b/src/infra/http/controllers/list.controller.ts
@@ -1,0 +1,42 @@
+import { Body, Controller, HttpException, HttpStatus, Param, Post } from '@nestjs/common';
+import { CreateListUseCase } from '@/app/use-cases/list/create-list.use-case';
+import { AddItemInListUseCase } from '@/app/use-cases/list/add-item-in-list.use-case';
+import { ListAlreadyExistsError, ListNotFoundError } from '@/app/use-cases/list/errors';
+
+@Controller('lists')
+export class ListController {
+  constructor(
+    private readonly createList: CreateListUseCase,
+    private readonly addItem: AddItemInListUseCase
+  ) {}
+
+  @Post()
+  async create(@Body() body: { name: string }) {
+    const result = await this.createList.execute({ name: body.name });
+    if (result.right()) {
+      return { success: true, list_id: result.value.listId };
+    }
+    if (result.value instanceof ListAlreadyExistsError) {
+      throw new HttpException(result.value.message, HttpStatus.CONFLICT);
+    }
+  }
+
+  @Post(':listId/items')
+  async addItemInList(
+    @Param('listId') listId: string,
+    @Body() body: { name: string; quantity: number }
+  ) {
+    const result = await this.addItem.execute({
+      listId,
+      name: body.name,
+      quantity: body.quantity,
+    });
+
+    if (result.right()) {
+      return { success: true, item_id: result.value.itemId };
+    }
+    if (result.value instanceof ListNotFoundError) {
+      throw new HttpException(result.value.message, HttpStatus.NOT_FOUND);
+    }
+  }
+}

--- a/src/infra/http/http.module.ts
+++ b/src/infra/http/http.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TouchClientAnonymousUseCase } from '@/app/use-cases/client/touch-client-anonymous.use-case';
+import { CreateListUseCase } from '@/app/use-cases/list/create-list.use-case';
+import { AddItemInListUseCase } from '@/app/use-cases/list/add-item-in-list.use-case';
+import { CanCreateNewListPolicy } from '@/app/use-cases/list/policies/can-create-new-list.policy';
+import { ClientController } from './controllers/client.controller';
+import { ListController } from './controllers/list.controller';
+import { DatabaseModule } from '../database/database.module';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [ClientController, ListController],
+  providers: [
+    TouchClientAnonymousUseCase,
+    CreateListUseCase,
+    AddItemInListUseCase,
+    CanCreateNewListPolicy,
+  ],
+})
+export class HttpModule {}

--- a/src/infra/http/presenters/client.presenter.ts
+++ b/src/infra/http/presenters/client.presenter.ts
@@ -1,0 +1,13 @@
+import { ClientAnonymous } from '@/domain/client/entities/client-anonymous.entity';
+import { ListPresenter } from './list.presenter';
+
+export class ClientAnonymousPresenter {
+  static toHTTP(client: ClientAnonymous) {
+    return {
+      id: client.id.toString(),
+      created_at: client.createdAt,
+      last_seen_at: client.lastSeenAt,
+      lists: client.lists.map((list) => ListPresenter.toHTTP(list)),
+    };
+  }
+}

--- a/src/infra/http/presenters/list-item.presenter.ts
+++ b/src/infra/http/presenters/list-item.presenter.ts
@@ -1,0 +1,14 @@
+import { ListItem } from '@/domain/list/entities/list-item.entity';
+
+export class ListItemPresenter {
+  static toHTTP(item: ListItem) {
+    return {
+      id: item.id.toString(),
+      list_id: item.listId,
+      name: item.name,
+      quantity: item.quantity,
+      created_at: item.createdAt,
+      updated_at: item.updatedAt,
+    };
+  }
+}

--- a/src/infra/http/presenters/list.presenter.ts
+++ b/src/infra/http/presenters/list.presenter.ts
@@ -1,0 +1,16 @@
+import { List } from '@/domain/list/entities/list.entity';
+import { ListItemPresenter } from './list-item.presenter';
+
+export class ListPresenter {
+  static toHTTP(list: List) {
+    return {
+      id: list.id.toString(),
+      name: list.name,
+      source: list.source,
+      created_at: list.createdAt,
+      updated_at: list.updatedAt,
+      deleted_at: list.deletedAt,
+      items: list.items.map((item) => ListItemPresenter.toHTTP(item)),
+    };
+  }
+}

--- a/test/app/use-cases/client/touch-client-anonymous.use-case.spec.ts
+++ b/test/app/use-cases/client/touch-client-anonymous.use-case.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TouchClientAnonymousUseCase } from '@/app/use-cases/client/touch-client-anonymous.use-case';
+import { InMemoryClientAnonymousRepository } from '../../in-memory/in-memory-client.repository';
+import { ClientAnonymous } from '@/domain/client/entities/client-anonymous.entity';
+import { UniqueID } from '@/core/value-objects/unique-id.vo';
+
+let repo: InMemoryClientAnonymousRepository;
+let useCase: TouchClientAnonymousUseCase;
+
+beforeEach(() => {
+  repo = new InMemoryClientAnonymousRepository();
+  useCase = new TouchClientAnonymousUseCase(repo);
+});
+
+describe('TouchClientAnonymousUseCase', () => {
+  it('creates a new client when not exists', async () => {
+    const result = await useCase.execute('abc');
+    expect(result.right()).toBe(true);
+    expect(repo.items.get('abc')).toBeTruthy();
+  });
+
+  it('updates last seen for existing client', async () => {
+    const client = ClientAnonymous.create({ lists: [] }, new UniqueID('abc'));
+    await repo.save(client);
+    const lastSeen = client.lastSeenAt;
+    await new Promise((r) => setTimeout(r, 10));
+    const result = await useCase.execute('abc');
+    expect(result.right()).toBe(true);
+    const stored = repo.items.get('abc')!;
+    expect(stored.lastSeenAt > (lastSeen ?? new Date(0))).toBe(true);
+  });
+});

--- a/test/app/use-cases/list/add-item-in-list.use-case.spec.ts
+++ b/test/app/use-cases/list/add-item-in-list.use-case.spec.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AddItemInListUseCase } from '@/app/use-cases/list/add-item-in-list.use-case';
+import { InMemoryListRepository } from '../../in-memory/in-memory-list.repository';
+import { InMemoryListItemRepository } from '../../in-memory/in-memory-list-item.repository';
+import { List } from '@/domain/list/entities/list.entity';
+import { ListNotFoundError } from '@/app/use-cases/list/errors';
+
+let listRepo: InMemoryListRepository;
+let itemRepo: InMemoryListItemRepository;
+let useCase: AddItemInListUseCase;
+
+beforeEach(() => {
+  listRepo = new InMemoryListRepository();
+  itemRepo = new InMemoryListItemRepository();
+  useCase = new AddItemInListUseCase(listRepo, itemRepo);
+});
+
+describe('AddItemInListUseCase', () => {
+  it('adds item into list', async () => {
+    const list = List.create({ name: 'Test', items: [], anonymousId: null });
+    await listRepo.save(list);
+    const result = await useCase.execute({
+      listId: list.id.toString(),
+      name: 'Apple',
+      quantity: 1,
+    });
+    expect(result.right()).toBe(true);
+    expect(itemRepo.items.length).toBe(1);
+  });
+
+  it('returns error when list not found', async () => {
+    const result = await useCase.execute({ listId: 'nope', name: 'Apple', quantity: 1 });
+    expect(result.left()).toBe(true);
+    expect(result.value).toBeInstanceOf(ListNotFoundError);
+  });
+});

--- a/test/app/use-cases/list/create-list.use-case.spec.ts
+++ b/test/app/use-cases/list/create-list.use-case.spec.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { InMemoryListRepository } from '../../in-memory/in-memory-list.repository';
+import { CanCreateNewListPolicy } from '@/app/use-cases/list/policies/can-create-new-list.policy';
+import { CreateListUseCase } from '@/app/use-cases/list/create-list.use-case';
+import { ListAlreadyExistsError } from '@/app/use-cases/list/errors';
+import { List } from '@/domain/list/entities/list.entity';
+
+let repo: InMemoryListRepository;
+let useCase: CreateListUseCase;
+
+beforeEach(() => {
+  repo = new InMemoryListRepository();
+  const policy = new CanCreateNewListPolicy(repo);
+  useCase = new CreateListUseCase(repo, policy);
+});
+
+describe('CreateListUseCase', () => {
+  it('creates a list', async () => {
+    const result = await useCase.execute({ name: 'Test' });
+    expect(result.right()).toBe(true);
+    expect(repo.items.size).toBe(1);
+  });
+
+  it('returns error when name already exists', async () => {
+    const list = List.create({ name: 'Test', items: [], anonymousId: null });
+    await repo.save(list);
+    const result = await useCase.execute({ name: 'Test' });
+    expect(result.left()).toBe(true);
+    expect(result.value).toBeInstanceOf(ListAlreadyExistsError);
+  });
+});

--- a/test/in-memory/in-memory-client.repository.ts
+++ b/test/in-memory/in-memory-client.repository.ts
@@ -1,0 +1,14 @@
+import { ClientAnonymousRepository } from '@/app/repositories/client.repository';
+import { ClientAnonymous } from '@/domain/client/entities/client-anonymous.entity';
+
+export class InMemoryClientAnonymousRepository extends ClientAnonymousRepository {
+  public items = new Map<string, ClientAnonymous>();
+
+  async findById(id: string): Promise<ClientAnonymous | null> {
+    return this.items.get(id) ?? null;
+  }
+
+  async save(client: ClientAnonymous): Promise<void> {
+    this.items.set(client.id.toString(), client);
+  }
+}

--- a/test/in-memory/in-memory-list-item.repository.ts
+++ b/test/in-memory/in-memory-list-item.repository.ts
@@ -1,0 +1,14 @@
+import { ListItemRepository, ISaveProps } from '@/app/repositories/list-item.repository';
+
+export class InMemoryListItemRepository extends ListItemRepository {
+  public items: ISaveProps[] = [];
+
+  async save(props: ISaveProps): Promise<void> {
+    const index = this.items.findIndex((i) => i.id === props.id);
+    if (index >= 0) {
+      this.items[index] = props;
+    } else {
+      this.items.push(props);
+    }
+  }
+}

--- a/test/in-memory/in-memory-list.repository.ts
+++ b/test/in-memory/in-memory-list.repository.ts
@@ -1,0 +1,21 @@
+import { ListRepository } from '@/app/repositories/list.repository';
+import { List } from '@/domain/list/entities/list.entity';
+
+export class InMemoryListRepository extends ListRepository {
+  public items = new Map<string, List>();
+
+  async save(list: List): Promise<void> {
+    this.items.set(list.id.toString(), list);
+  }
+
+  async findByName(name: string): Promise<List | null> {
+    for (const list of this.items.values()) {
+      if (list.name === name) return list;
+    }
+    return null;
+  }
+
+  async findById(id: string): Promise<List | null> {
+    return this.items.get(id) ?? null;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- create http module with controllers for touch anonymous client and list actions
- send entities in snake_case using presenters
- support unit tests with in-memory repositories
- add vitest configuration

## Testing
- `npx prettier --write "src/**/*.ts" "test/**/*.ts"`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850adf815f48333aa621075ef41226f